### PR TITLE
Target netstandard instead of netcoreapp

### DIFF
--- a/src/Syncromatics.Clients.WaySine/Syncromatics.Clients.WaySine.csproj
+++ b/src/Syncromatics.Clients.WaySine/Syncromatics.Clients.WaySine.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Syncromatics.Clients.WaySine</AssemblyName>
     <RootNamespace>Syncromatics.Clients.WaySine</RootNamespace>


### PR DESCRIPTION
...this way we can actually use it in the .net framework app we are trying to use it in.